### PR TITLE
Combining alignment and reference alignment by ids

### DIFF
--- a/modules/evaluateAlignment.nf
+++ b/modules/evaluateAlignment.nf
@@ -8,8 +8,7 @@ process EVAL_ALIGNMENT {
 
     input:
     val align_type
-    val id
-    tuple file (test_alignment), val (id_ref), file (ref_alignment)
+    tuple  val (id), file (test_alignment), file (ref_alignment)
     val align_method
     val tree_method
     val bucket_size
@@ -57,8 +56,7 @@ process EASEL_INFO {
 
     input:
     val align_type
-    val id
-    tuple file (test_alignment), val (id_ref), file (ref_alignment)
+    tuple  val (id), file (test_alignment), file (ref_alignment)
     val align_method
     val tree_method
     val bucket_size
@@ -86,8 +84,7 @@ process HOMOPLASY {
 
     input:
     val align_type
-    val id
-    tuple file (test_alignment), val (id_ref), file (ref_alignment)
+    tuple  val (id), file (test_alignment), file (ref_alignment)
     val align_method
     val tree_method
     val bucket_size
@@ -125,8 +122,7 @@ process METRICS {
 
     input:
         val align_type
-        val id
-        tuple file (test_alignment), val (id_ref), file (ref_alignment)
+        tuple  val (id), file (test_alignment), file (ref_alignment)
         val align_method
         val tree_method
         val bucket_size

--- a/modules/generateAlignment.nf
+++ b/modules/generateAlignment.nf
@@ -17,11 +17,12 @@ process REG_ALIGNER {
     path (guide_tree)
 
     output:
-    val id, emit: id
+    // val id, emit: id
     val align_method, emit: alignMethod
     val tree_method, emit: treeMethod
     val bucket_size, emit: bucketSize
-    path "${id}.reg_${bucket_size}.${align_method}.with.${tree_method}.tree.aln", emit: alignmentFile
+    // path "${id}.reg_${bucket_size}.${align_method}.with.${tree_method}.tree.aln", emit: alignmentFile
+    tuple val (id), path ("${id}.reg_${bucket_size}.${align_method}.with.${tree_method}.tree.aln"), emit: alignmentFile
     path "${id}.homoplasy", emit: homoplasyFile
     path ".command.trace", emit: metricFile
 
@@ -103,8 +104,7 @@ process POOL_ALIGNER {
     tuple val(id), val(tree_method), file(guide_tree)
 
     output:
-    val id, emit:id
-    path "${id}.pool_${bucket_size}.${align_method}.with.${tree_method}.tree.aln", emit: alignmentFile
+    tuple val (id), path ("${id}.pool_${bucket_size}.${align_method}.with.${tree_method}.tree.aln"), emit: alignmentFile
     path "${id}.homoplasy", emit: homoplasyFile
     path ".command.trace", emit: metricFile
 

--- a/modules/prog_analysis.nf
+++ b/modules/prog_analysis.nf
@@ -28,18 +28,16 @@ workflow PROG_ANALYSIS {
     
     PROG_ALIGNER (seqs_ch, align_methods, trees_ch)
 
-    // prog_alignment_plus_ref = PROG_ALIGNER.out.alignmentFile.combine(refs_ch) //#del
     refs_ch
         .cross (PROG_ALIGNER.out.alignmentFile)
         .map { it -> [ it[1][0], it[1][1], it[0][1] ] }
         .set { prog_alignment_plus_ref }
 
     if (params.evaluate){
-      // EVAL_ALIGNMENT ("progressive", PROG_ALIGNER.out.id, prog_alignment_plus_ref, align_methods, tree_methods, "NA") //#del
       EVAL_ALIGNMENT ("progressive", prog_alignment_plus_ref, align_methods, tree_methods, "NA")
     }
     if (params.gapCount){
-      GAPS_PROGRESSIVE("progressive", PROG_ALIGNER.out.id, PROG_ALIGNER.out.alignmentFile, align_methods, tree_methods, "NA") //#del
+      GAPS_PROGRESSIVE("progressive", PROG_ALIGNER.out.id, PROG_ALIGNER.out.alignmentFile, align_methods, tree_methods, "NA")
     }
     if (params.metrics){
       METRICS("progressive", prog_alignment_plus_ref, align_methods, tree_methods, "NA", PROG_ALIGNER.out.metricFile)

--- a/modules/prog_analysis.nf
+++ b/modules/prog_analysis.nf
@@ -28,18 +28,23 @@ workflow PROG_ANALYSIS {
     
     PROG_ALIGNER (seqs_ch, align_methods, trees_ch)
 
-    prog_alignment_plus_ref = PROG_ALIGNER.out.alignmentFile.combine(refs_ch)
+    // prog_alignment_plus_ref = PROG_ALIGNER.out.alignmentFile.combine(refs_ch) //#del
+    refs_ch
+        .cross (PROG_ALIGNER.out.alignmentFile)
+        .map { it -> [ it[1][0], it[1][1], it[0][1] ] }
+        .set { prog_alignment_plus_ref }
 
     if (params.evaluate){
-      EVAL_ALIGNMENT ("progressive", PROG_ALIGNER.out.id, prog_alignment_plus_ref, align_methods, tree_methods, "NA")
+      // EVAL_ALIGNMENT ("progressive", PROG_ALIGNER.out.id, prog_alignment_plus_ref, align_methods, tree_methods, "NA") //#del
+      EVAL_ALIGNMENT ("progressive", prog_alignment_plus_ref, align_methods, tree_methods, "NA")
     }
     if (params.gapCount){
-      GAPS_PROGRESSIVE("progressive",PROG_ALIGNER.out.id, PROG_ALIGNER.out.alignmentFile, align_methods, tree_methods, "NA")
+      GAPS_PROGRESSIVE("progressive", PROG_ALIGNER.out.id, PROG_ALIGNER.out.alignmentFile, align_methods, tree_methods, "NA") //#del
     }
     if (params.metrics){
-      METRICS("progressive",PROG_ALIGNER.out.id, prog_alignment_plus_ref, align_methods, tree_methods, "NA", PROG_ALIGNER.out.metricFile)
+      METRICS("progressive", prog_alignment_plus_ref, align_methods, tree_methods, "NA", PROG_ALIGNER.out.metricFile)
     }
-    EASEL_INFO ("progressive",PROG_ALIGNER.out.id, prog_alignment_plus_ref, align_methods, tree_methods, "NA")
+    EASEL_INFO ("progressive", prog_alignment_plus_ref, align_methods, tree_methods, "NA")
 
   //emit: 
 }

--- a/modules/reg_analysis.nf
+++ b/modules/reg_analysis.nf
@@ -29,7 +29,6 @@ workflow REG_ANALYSIS {
       REG_ALIGNER (seqs_ch, align_method, bucket_size, tree_method, trees)
     }
 
-    // alignment_plus_ref = REG_ALIGNER.out.alignmentFile.combine(refs_ch) //#del
     refs_ch
         .cross (REG_ALIGNER.out.alignmentFile)
         .map { it -> [ it[1][0], it[1][1], it[0][1] ] }
@@ -38,19 +37,15 @@ workflow REG_ANALYSIS {
     //REG_ALIGNER.out.alignmentFile.cross(refs_ch).view()
 
     if (params.evaluate){
-      // EVAL_ALIGNMENT ("regressive", REG_ALIGNER.out.id, alignment_plus_ref, REG_ALIGNER.out.alignMethod, REG_ALIGNER.out.treeMethod, REG_ALIGNER.out.bucketSize) //#del
       EVAL_ALIGNMENT ("regressive", alignment_plus_ref, REG_ALIGNER.out.alignMethod, REG_ALIGNER.out.treeMethod, REG_ALIGNER.out.bucketSize)
     }
     return
     if (params.homoplasy){
-      // HOMOPLASY("regressive",REG_ALIGNER.out.id, alignment_plus_ref, REG_ALIGNER.out.alignMethod, REG_ALIGNER.out.treeMethod, REG_ALIGNER.out.bucketSize, REG_ALIGNER.out.homoplasyFile) //#del
       HOMOPLASY("regressive", alignment_plus_ref, REG_ALIGNER.out.alignMethod, REG_ALIGNER.out.treeMethod, REG_ALIGNER.out.bucketSize, REG_ALIGNER.out.homoplasyFile)
     }
     if (params.metrics){
-      // METRICS("regressive",REG_ALIGNER.out.id, alignment_plus_ref, REG_ALIGNER.out.alignMethod, REG_ALIGNER.out.treeMethod, REG_ALIGNER.out.bucketSize, REG_ALIGNER.out.metricFile) //#del
       METRICS("regressive", alignment_plus_ref, REG_ALIGNER.out.alignMethod, REG_ALIGNER.out.treeMethod, REG_ALIGNER.out.bucketSize, REG_ALIGNER.out.metricFile)
     }
-    // EASEL_INFO ("regressive",REG_ALIGNER.out.id, alignment_plus_ref, REG_ALIGNER.out.alignMethod, REG_ALIGNER.out.treeMethod, REG_ALIGNER.out.bucketSize) //#del
     // EASEL_INFO ("regressive", alignment_plus_ref, REG_ALIGNER.out.alignMethod, REG_ALIGNER.out.treeMethod, REG_ALIGNER.out.bucketSize)
 
 }
@@ -76,25 +71,20 @@ workflow POOL_ANALYSIS {
     
     POOL_ALIGNER (seqs_ch, align_methods, bucket_size, trees_ch)
 
-    // pool_alignment_plus_ref = POOL_ALIGNER.out.alignmentFile.combine(refs_ch) //#del
     refs_ch
         .cross (POOL_ALIGNER.out.alignmentFile)
         .map { it -> [ it[1][0], it[1][1], it[0][1] ] }
         .set { pool_alignment_plus_ref }
 
     if (params.evaluate){
-      // EVAL_ALIGNMENT ("pool", POOL_ALIGNER.out.id, pool_alignment_plus_ref, align_methods, tree_methods, bucket_size) // #del
       EVAL_ALIGNMENT ("pool", pool_alignment_plus_ref, align_methods, tree_methods, bucket_size)
     }
     if (params.homoplasy){
-      // HOMOPLASY("pool", POOL_ALIGNER.out.id,  pool_alignment_plus_ref, align_methods, tree_methods, bucket_size, POOL_ALIGNER.out.homoplasyFile) // #del
       HOMOPLASY ("pool", pool_alignment_plus_ref, align_methods, tree_methods, bucket_size, POOL_ALIGNER.out.homoplasyFile)
     }
     if (params.metrics){
-      // METRICS("pool", POOL_ALIGNER.out.id, pool_alignment_plus_ref, align_methods, tree_methods, bucket_size, POOL_ALIGNER.out.metricFile)  // #del
       METRICS("pool", pool_alignment_plus_ref, align_methods, tree_methods, bucket_size, POOL_ALIGNER.out.metricFile)
     }
-    // EASEL_INFO ("pool", POOL_ALIGNER.out.id, pool_alignment_plus_ref, align_methods, tree_methods, bucket_size) // #del
     EASEL_INFO ("pool", pool_alignment_plus_ref, align_methods, tree_methods, bucket_size)
 
   //emit: 
@@ -122,25 +112,20 @@ workflow SLAVE_ANALYSIS {
     
     SLAVE_ALIGNER (seqs_ch, align_methods, bucket_size, trees_ch, slave_method)
 
-    // slave_alignment_plus_ref = SLAVE_ALIGNER.out.alignmentFile.combine(refs_ch) //#del
     refs_ch
         .cross (SLAVE_ALIGNER.out.alignmentFile)
         .map { it -> [ it[1][0], it[1][1], it[0][1] ] }
         .set { slave_alignment_plus_ref }
 
     if (params.evaluate){
-      // EVAL_ALIGNMENT ("slave",SLAVE_ALIGNER.out.id, slave_alignment_plus_ref, align_methods, SLAVE_ALIGNER.out.tree_method, bucket_size) //#del
       EVAL_ALIGNMENT ("slave", slave_alignment_plus_ref, align_methods, SLAVE_ALIGNER.out.tree_method, bucket_size)
     }
     if (params.homoplasy){
-      // HOMOPLASY("slave",SLAVE_ALIGNER.out.id, slave_alignment_plus_ref, align_methods, SLAVE_ALIGNER.out.tree_method, bucket_size, SLAVE_ALIGNER.out.homoplasyFile) //#del
       HOMOPLASY("slave", slave_alignment_plus_ref, align_methods, SLAVE_ALIGNER.out.tree_method, bucket_size, SLAVE_ALIGNER.out.homoplasyFile)
     }
     if (params.metrics){
-      // METRICS("slave", SLAVE_ALIGNER.out.id, slave_alignment_plus_ref, align_methods, SLAVE_ALIGNER.out.tree_method, bucket_size, SLAVE_ALIGNER.out.metricFile) //#del
       METRICS("slave", slave_alignment_plus_ref, align_methods, SLAVE_ALIGNER.out.tree_method, bucket_size, SLAVE_ALIGNER.out.metricFile)
     }
-    // EASEL_INFO ("slave", SLAVE_ALIGNER.out.id, slave_alignment_plus_ref, align_methods, SLAVE_ALIGNER.out.tree_method, bucket_size) //#del
     EASEL_INFO ("slave", slave_alignment_plus_ref, align_methods, SLAVE_ALIGNER.out.tree_method, bucket_size)
 
   //emit: 

--- a/modules/reg_analysis.nf
+++ b/modules/reg_analysis.nf
@@ -29,18 +29,29 @@ workflow REG_ANALYSIS {
       REG_ALIGNER (seqs_ch, align_method, bucket_size, tree_method, trees)
     }
 
-    alignment_plus_ref = REG_ALIGNER.out.alignmentFile.combine(refs_ch)
+    // alignment_plus_ref = REG_ALIGNER.out.alignmentFile.combine(refs_ch) //#del
+    refs_ch
+        .cross (REG_ALIGNER.out.alignmentFile)
+        .map { it -> [ it[1][0], it[1][1], it[0][1] ] }
+        .set { alignment_plus_ref }
+
+    //REG_ALIGNER.out.alignmentFile.cross(refs_ch).view()
 
     if (params.evaluate){
-      EVAL_ALIGNMENT ("regressive", REG_ALIGNER.out.id, alignment_plus_ref, REG_ALIGNER.out.alignMethod, REG_ALIGNER.out.treeMethod, REG_ALIGNER.out.bucketSize)
+      // EVAL_ALIGNMENT ("regressive", REG_ALIGNER.out.id, alignment_plus_ref, REG_ALIGNER.out.alignMethod, REG_ALIGNER.out.treeMethod, REG_ALIGNER.out.bucketSize) //#del
+      EVAL_ALIGNMENT ("regressive", alignment_plus_ref, REG_ALIGNER.out.alignMethod, REG_ALIGNER.out.treeMethod, REG_ALIGNER.out.bucketSize)
     }
+    return
     if (params.homoplasy){
-      HOMOPLASY("regressive",REG_ALIGNER.out.id, alignment_plus_ref, REG_ALIGNER.out.alignMethod, REG_ALIGNER.out.treeMethod, REG_ALIGNER.out.bucketSize, REG_ALIGNER.out.homoplasyFile)
+      // HOMOPLASY("regressive",REG_ALIGNER.out.id, alignment_plus_ref, REG_ALIGNER.out.alignMethod, REG_ALIGNER.out.treeMethod, REG_ALIGNER.out.bucketSize, REG_ALIGNER.out.homoplasyFile) //#del
+      HOMOPLASY("regressive", alignment_plus_ref, REG_ALIGNER.out.alignMethod, REG_ALIGNER.out.treeMethod, REG_ALIGNER.out.bucketSize, REG_ALIGNER.out.homoplasyFile)
     }
     if (params.metrics){
-      METRICS("regressive",REG_ALIGNER.out.id, alignment_plus_ref, REG_ALIGNER.out.alignMethod, REG_ALIGNER.out.treeMethod, REG_ALIGNER.out.bucketSize, REG_ALIGNER.out.metricFile)
+      // METRICS("regressive",REG_ALIGNER.out.id, alignment_plus_ref, REG_ALIGNER.out.alignMethod, REG_ALIGNER.out.treeMethod, REG_ALIGNER.out.bucketSize, REG_ALIGNER.out.metricFile) //#del
+      METRICS("regressive", alignment_plus_ref, REG_ALIGNER.out.alignMethod, REG_ALIGNER.out.treeMethod, REG_ALIGNER.out.bucketSize, REG_ALIGNER.out.metricFile)
     }
-    //EASEL_INFO ("regressive",REG_ALIGNER.out.id, alignment_plus_ref, REG_ALIGNER.out.alignMethod, REG_ALIGNER.out.treeMethod, REG_ALIGNER.out.bucketSize)
+    // EASEL_INFO ("regressive",REG_ALIGNER.out.id, alignment_plus_ref, REG_ALIGNER.out.alignMethod, REG_ALIGNER.out.treeMethod, REG_ALIGNER.out.bucketSize) //#del
+    // EASEL_INFO ("regressive", alignment_plus_ref, REG_ALIGNER.out.alignMethod, REG_ALIGNER.out.treeMethod, REG_ALIGNER.out.bucketSize)
 
 }
 
@@ -65,18 +76,26 @@ workflow POOL_ANALYSIS {
     
     POOL_ALIGNER (seqs_ch, align_methods, bucket_size, trees_ch)
 
-    pool_alignment_plus_ref = POOL_ALIGNER.out.alignmentFile.combine(refs_ch)
+    // pool_alignment_plus_ref = POOL_ALIGNER.out.alignmentFile.combine(refs_ch) //#del
+    refs_ch
+        .cross (POOL_ALIGNER.out.alignmentFile)
+        .map { it -> [ it[1][0], it[1][1], it[0][1] ] }
+        .set { pool_alignment_plus_ref }
 
     if (params.evaluate){
-      EVAL_ALIGNMENT ("pool",POOL_ALIGNER.out.id, pool_alignment_plus_ref, align_methods, tree_methods, bucket_size)
+      // EVAL_ALIGNMENT ("pool", POOL_ALIGNER.out.id, pool_alignment_plus_ref, align_methods, tree_methods, bucket_size) // #del
+      EVAL_ALIGNMENT ("pool", pool_alignment_plus_ref, align_methods, tree_methods, bucket_size)
     }
     if (params.homoplasy){
-      HOMOPLASY("pool",POOL_ALIGNER.out.id,  pool_alignment_plus_ref, align_methods, tree_methods, bucket_size, POOL_ALIGNER.out.homoplasyFile)
+      // HOMOPLASY("pool", POOL_ALIGNER.out.id,  pool_alignment_plus_ref, align_methods, tree_methods, bucket_size, POOL_ALIGNER.out.homoplasyFile) // #del
+      HOMOPLASY ("pool", pool_alignment_plus_ref, align_methods, tree_methods, bucket_size, POOL_ALIGNER.out.homoplasyFile)
     }
     if (params.metrics){
-      METRICS("pool", POOL_ALIGNER.out.id, pool_alignment_plus_ref, align_methods, tree_methods, bucket_size, POOL_ALIGNER.out.metricFile)
+      // METRICS("pool", POOL_ALIGNER.out.id, pool_alignment_plus_ref, align_methods, tree_methods, bucket_size, POOL_ALIGNER.out.metricFile)  // #del
+      METRICS("pool", pool_alignment_plus_ref, align_methods, tree_methods, bucket_size, POOL_ALIGNER.out.metricFile)
     }
-    EASEL_INFO ("pool", POOL_ALIGNER.out.id, pool_alignment_plus_ref, align_methods, tree_methods, bucket_size)
+    // EASEL_INFO ("pool", POOL_ALIGNER.out.id, pool_alignment_plus_ref, align_methods, tree_methods, bucket_size) // #del
+    EASEL_INFO ("pool", pool_alignment_plus_ref, align_methods, tree_methods, bucket_size)
 
   //emit: 
 }
@@ -103,18 +122,26 @@ workflow SLAVE_ANALYSIS {
     
     SLAVE_ALIGNER (seqs_ch, align_methods, bucket_size, trees_ch, slave_method)
 
-    slave_alignment_plus_ref = SLAVE_ALIGNER.out.alignmentFile.combine(refs_ch)
+    // slave_alignment_plus_ref = SLAVE_ALIGNER.out.alignmentFile.combine(refs_ch) //#del
+    refs_ch
+        .cross (SLAVE_ALIGNER.out.alignmentFile)
+        .map { it -> [ it[1][0], it[1][1], it[0][1] ] }
+        .set { slave_alignment_plus_ref }
 
     if (params.evaluate){
-      EVAL_ALIGNMENT ("slave",SLAVE_ALIGNER.out.id, slave_alignment_plus_ref, align_methods, SLAVE_ALIGNER.out.tree_method, bucket_size)
+      // EVAL_ALIGNMENT ("slave",SLAVE_ALIGNER.out.id, slave_alignment_plus_ref, align_methods, SLAVE_ALIGNER.out.tree_method, bucket_size) //#del
+      EVAL_ALIGNMENT ("slave", slave_alignment_plus_ref, align_methods, SLAVE_ALIGNER.out.tree_method, bucket_size)
     }
     if (params.homoplasy){
-      HOMOPLASY("slave",SLAVE_ALIGNER.out.id, slave_alignment_plus_ref, align_methods, SLAVE_ALIGNER.out.tree_method, bucket_size, SLAVE_ALIGNER.out.homoplasyFile)
+      // HOMOPLASY("slave",SLAVE_ALIGNER.out.id, slave_alignment_plus_ref, align_methods, SLAVE_ALIGNER.out.tree_method, bucket_size, SLAVE_ALIGNER.out.homoplasyFile) //#del
+      HOMOPLASY("slave", slave_alignment_plus_ref, align_methods, SLAVE_ALIGNER.out.tree_method, bucket_size, SLAVE_ALIGNER.out.homoplasyFile)
     }
     if (params.metrics){
-      METRICS("slave",SLAVE_ALIGNER.out.id, slave_alignment_plus_ref, align_methods, SLAVE_ALIGNER.out.tree_method, bucket_size, SLAVE_ALIGNER.out.metricFile)
+      // METRICS("slave", SLAVE_ALIGNER.out.id, slave_alignment_plus_ref, align_methods, SLAVE_ALIGNER.out.tree_method, bucket_size, SLAVE_ALIGNER.out.metricFile) //#del
+      METRICS("slave", slave_alignment_plus_ref, align_methods, SLAVE_ALIGNER.out.tree_method, bucket_size, SLAVE_ALIGNER.out.metricFile)
     }
-    EASEL_INFO ("slave",SLAVE_ALIGNER.out.id, slave_alignment_plus_refs, align_methods, SLAVE_ALIGNER.out.tree_method, bucket_size)
+    // EASEL_INFO ("slave", SLAVE_ALIGNER.out.id, slave_alignment_plus_ref, align_methods, SLAVE_ALIGNER.out.tree_method, bucket_size) //#del
+    EASEL_INFO ("slave", slave_alignment_plus_ref, align_methods, SLAVE_ALIGNER.out.tree_method, bucket_size)
 
   //emit: 
 }


### PR DESCRIPTION
Alignments should be paired with its respective reference alignment. To this end, they are combined now using the respective IDs. Processes using these type of channel now declare as (input or output) channel a tuple that is defined in this way:

`tuple val(id), path(alignment), path(reference_alignment`