### PR TITLE
Solve problems with nextflow version and variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on: [push, pull_request]
 jobs:
   test_progressive:
     env:
-      NXF_VER: '20.04.01'
+      NXF_VER: '20.04.1'
       NXF_ANSI_LOG: false
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
@@ -27,7 +27,7 @@ jobs:
 
   test_regressive:
     env:
-      NXF_VER: '20.04.01'
+      NXF_VER: '20.04.1'
       NXF_ANSI_LOG: false
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
@@ -49,7 +49,7 @@ jobs:
   
   test_slave:
     env:
-      NXF_VER: '20.04.01'
+      NXF_VER: '20.04.1'
       NXF_ANSI_LOG: false
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
@@ -72,7 +72,7 @@ jobs:
 
   test_dynamic:
     env:
-      NXF_VER: '20.04.01'
+      NXF_VER: '20.04.1'
       NXF_ANSI_LOG: false
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
@@ -95,7 +95,7 @@ jobs:
           
   test_pool:
     env:
-      NXF_VER: '20.04.01'
+      NXF_VER: '20.04.1'
       NXF_ANSI_LOG: false
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"

--- a/modules/functions.nf
+++ b/modules/functions.nf
@@ -2,7 +2,7 @@
 
 def set_templates_path () {
     if( !nextflow.version.matches('20.04.1-edge+') ) {
-        println "It is advisable to run this workflow with Nextflow version 20.04.01-edge or greater -- You are running version $nextflow.version"
+        println "It is advisable to run this workflow with Nextflow version 20.04.1-edge or greater -- You are running version $nextflow.version"
         path_templates = projectDir.name == "nf-benchmark" ? "$projectDir/modules/regressive_alignment/modules/templates" : "$projectDir/modules/templates"
     }
     else {

--- a/modules/functions.nf
+++ b/modules/functions.nf
@@ -3,7 +3,7 @@
 def set_templates_path () {
     if( !nextflow.version.matches('20.04.1-edge+') ) {
         println "It is advisable to run this workflow with Nextflow version 20.04.1-edge or greater -- You are running version $nextflow.version"
-        path_templates = projectDir.name == "nf-benchmark" ? "$projectDir/modules/regressive_alignment/modules/templates" : "$projectDir/modules/templates"
+        path_templates = workflow.commandLine.contains('--pipeline') ? "$baseDir/modules/regressive_alignment/modules/templates" : "$baseDir/modules/templates"
     }
     else {
         path_templates = "${moduleDir}/templates"


### PR DESCRIPTION
On [this](https://github.com/edgano/nf_regressive_modules/pull/4) PR, it was implemented how to set the `templateDir` when different version of nextflow were used. Since some nextflow variables are only implemented after `20.04.1-edge` such as `projectDir` this was breaking the CI. Moreover, some warnings were the nextflow version was misspelled were fixed.